### PR TITLE
add osx-app-shim example

### DIFF
--- a/extras/README.md
+++ b/extras/README.md
@@ -1,0 +1,27 @@
+# paquo - extras
+
+We'll include some potentially interesting code snippets in here, in case they might be useful to someone.
+Feel free to open issues if something is unclear.
+
+### osx_app_shim
+
+This snippet might come in handy for you, if you're interested in using a custom paquo script as an app on OSX.
+The simple example uses paquo's commandline "open" subcommand to open a QuPath project, but you can easily adapt the
+script to do whatever complex thing you want to achieve.
+
+To create a usable OSX app install `py2app` in you conda environment and run:
+
+```console
+$> cd extras/osx_app_shim
+$> python setup.py py2app -A
+``` 
+ 
+This will create an app in `extras/osx_app_shim/dist/PaquoOpenQpZip.app` in alias mode.
+Please refer to the `py2app` documentation if you need the app to be portable.
+
+You can now run
+```console
+$> cd extras/osx_app_shim/dist
+$> open -a PaquoOpenQpZip.app ~/path-to-my-wonderful/example-qupath-project
+``` 
+and it will launch QuPath with the example-qupath-project.

--- a/extras/osx_app_shim/PaquoOpenQpZip.py
+++ b/extras/osx_app_shim/PaquoOpenQpZip.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import sys
+from paquo._cli import open_qupath
+
+try:
+    sys.exit(open_qupath(sys.argv[1]))
+except BaseException:
+    sys.exit(1)

--- a/extras/osx_app_shim/setup.py
+++ b/extras/osx_app_shim/setup.py
@@ -1,0 +1,13 @@
+"""Paquo OSX app shim example"""
+from setuptools import setup
+
+setup(
+    app=["PaquoOpenQpZip.py"],
+    data_files=[],
+    options={
+        "py2app": {
+            "argv_emulation": 1,
+        }
+    },
+    setup_requires=["py2app"],
+)

--- a/paquo/__main__.py
+++ b/paquo/__main__.py
@@ -6,7 +6,7 @@ from itertools import repeat
 from pathlib import Path
 
 from paquo._cli import subcommand, argument, DirectoryType, \
-    config_print_settings, config_print_defaults, list_project, export_annotations, create_project
+    config_print_settings, config_print_defaults, list_project, export_annotations, create_project, open_qupath
 from paquo._config import PAQUO_CONFIG_FILENAME, get_searchtree
 
 # noinspection PyTypeChecker
@@ -177,6 +177,19 @@ def export(args, subparser):
     except IndexError:
         print(f"ERROR: image index {args.image_idx} out of range")
         return 1
+    return 0
+
+
+@subcommand(
+    argument('project_path', nargs='?', default=None, help="path to your qupath project file/folder"),
+)
+def open_(args, subparser):
+    """open qupath with a specified project"""
+    if args.project_path is None:
+        print(subparser.format_help())
+        return 0
+
+    open_qupath(args.project_path)
     return 0
 
 

--- a/paquo/__main__.py
+++ b/paquo/__main__.py
@@ -6,7 +6,8 @@ from itertools import repeat
 from pathlib import Path
 
 from paquo._cli import subcommand, argument, DirectoryType, \
-    config_print_settings, config_print_defaults, list_project, export_annotations, create_project, open_qupath
+    config_print_settings, config_print_defaults, list_project, export_annotations, create_project, open_qupath, \
+    qpzip_project
 from paquo._config import PAQUO_CONFIG_FILENAME, get_searchtree
 
 # noinspection PyTypeChecker
@@ -190,6 +191,19 @@ def open_(args, subparser):
         return 0
 
     open_qupath(args.project_path)
+    return 0
+
+
+@subcommand(
+    argument('project_path', nargs='?', default=None, help="path to your qupath project file/folder"),
+)
+def qpzip(args, subparser):
+    """create a qpzip archive of a project"""
+    if args.project_path is None:
+        print(subparser.format_help())
+        return 0
+
+    qpzip_project(args.project_path)
     return 0
 
 

--- a/paquo/_cli.py
+++ b/paquo/_cli.py
@@ -220,3 +220,24 @@ def open_qupath(project_path):
             raise ValueError(f"Not a qupath project: '{p}'")
 
         subprocess.run([qupath, '-p', p.resolve()])
+
+
+# -- quzip related commands -------------------------------------------
+
+def qpzip_project(project_path):
+    """create a zip archive of a qupath project that can be used with `paquo open`"""
+    import shutil
+    from tempfile import TemporaryDirectory
+
+    p = Path(project_path).expanduser().absolute()
+    if p.is_dir():
+        p /= "project.qpproj"
+    if not (p.is_file() and p.suffix == ".qpproj"):
+        raise ValueError(f"Not a qupath project: '{p}'")
+
+    project_path = p.parent
+    with TemporaryDirectory() as tmpdir:
+        tmp_base_name = Path(tmpdir) / project_path.name
+        tmp_zip = shutil.make_archive(tmp_base_name, "zip", root_dir=project_path, base_dir=".")
+        qpzip = shutil.move(tmp_zip, project_path.with_suffix(".qpzip"))
+    print(f"created: {qpzip}")


### PR DESCRIPTION
This PR relies on #48 to be merged.
Requires:
- [ ] add tests

It adds an example for creating an OSX app via py2app using some paquo code.
Specifically this example allows opening zipped QuPath projects with their file extension changed to `qpzip` via paquo to launch QuPath.

I could imagine that we can add more code snippets, that currently have no clear path for being included in paquo, but might be interesting for others.