### PR TITLE
Add possibility to remove image from QuPath project

### DIFF
--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -273,6 +273,18 @@ class QuPathProject:
             # update the proxy
             self._image_entries_proxy.refresh()
 
+    # @redirect(stderr=True, stdout=True)
+    def remove_image(self, image_entry_id):
+        # Check if image is in project:
+        entry_ids = [im.entry_id for im in self.images]
+        assert image_entry_id in entry_ids, "Image with entry id {} not found and cannot be removed".format(image_entry_id)
+        entry = self.images[entry_ids.index(image_entry_id)]
+
+        # Remove image and update the project:
+        self.java_object.removeImage(entry.java_object, True)
+        self.save(images=False)
+
+
     @redirect(stderr=True, stdout=True)
     def add_image(self,
                   image_id: SimpleFileImageId,

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -434,7 +434,7 @@ class QuPathProject:
     @redirect(stderr=True, stdout=True)
     def remove_image(
         self,
-        image_entry: QuPathProjectImageEntry,
+        image_entry: Union[QuPathProjectImageEntry, int],
     ) -> None:
         """
         Delete an image from the QuPath project.
@@ -444,6 +444,8 @@ class QuPathProject:
         image_entry:
             the image entry to be removed
         """
+        if isinstance(image_entry, int):
+            image_entry = self.images[image_entry]
         if not isinstance(image_entry, QuPathProjectImageEntry):
             raise TypeError(
                 f"expected QuPathProjectImageEntry, got: {type(image_entry).__name__!r}"

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 from contextlib import contextmanager
 from contextlib import nullcontext
-from urllib.parse import urlparse
 from typing import Any
 from typing import Callable
 from typing import ContextManager
@@ -18,6 +17,7 @@ from typing import Sequence
 from typing import Tuple
 from typing import Union
 from typing import overload
+from urllib.parse import urlsplit
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -442,7 +442,7 @@ class QuPathProject:
         :param ensure_exists: If True, raises an error if the image is not found in the project
         """
         # Convert image path to uri (if it was not already one):
-        image_uri = self._image_provider.uri(urlparse(image_path).path)
+        image_uri = self._image_provider.uri(urlsplit(image_path).path)
 
         # Check if image is in the project:
         current_uris = [image.uri for image in self.images]

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -239,6 +239,12 @@ def test_project_add_unsupported_image(new_project, tmp_path):
         new_project.add_image(image)
 
 
+def test_project_remove_image(new_project, svs_small):
+    # Add an image to the project and then remove it:
+    entry = new_project.add_image(svs_small)
+    new_project.remove_image(entry.uri)
+    assert len(new_project.images) == 0
+
 def test_project_image_slicing(new_project):
     _ = new_project.images[slice(None, None, None)]
 

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -241,9 +241,16 @@ def test_project_add_unsupported_image(new_project, tmp_path):
 
 def test_project_remove_image(new_project, svs_small):
     # Add an image to the project and then remove it:
-    entry = new_project.add_image(svs_small)
-    new_project.remove_image(entry.uri)
+    new_project.add_image(svs_small)
+    assert len(new_project.images) == 1
+    new_project.remove_image(new_project.images[0])
     assert len(new_project.images) == 0
+
+
+def test_project_remove_image_wrong_type(new_project):
+    with pytest.raises(TypeError):
+        new_project.remove_image("some/file.svs")
+
 
 def test_project_image_slicing(new_project):
     _ = new_project.images[slice(None, None, None)]

--- a/paquo/tests/test_readonly.py
+++ b/paquo/tests/test_readonly.py
@@ -124,6 +124,9 @@ def test_project_attrs_and_methods(readonly_project, copy_svs_small):
             a.callmethod("add_image", copy_svs_small, allow_duplicates=True)
         with pytest.raises(IOError):
             a.callmethod("save")
+        with pytest.raises(IOError):
+            image_id = qp.images[0].entry_id
+            a.callmethod("remove_image", image_id)
 
         # test that we can reassign uri's even in readonly mode
         cur_uri = qp.images[0].uri

--- a/paquo/tests/test_readonly.py
+++ b/paquo/tests/test_readonly.py
@@ -125,8 +125,8 @@ def test_project_attrs_and_methods(readonly_project, copy_svs_small):
         with pytest.raises(IOError):
             a.callmethod("save")
         with pytest.raises(IOError):
-            image_id = qp.images[0].entry_id
-            a.callmethod("remove_image", image_id)
+            image_uri = qp.images[0].uri
+            a.callmethod("remove_image", image_uri)
 
         # test that we can reassign uri's even in readonly mode
         cur_uri = qp.images[0].uri

--- a/paquo/tests/test_readonly.py
+++ b/paquo/tests/test_readonly.py
@@ -125,8 +125,8 @@ def test_project_attrs_and_methods(readonly_project, copy_svs_small):
         with pytest.raises(IOError):
             a.callmethod("save")
         with pytest.raises(IOError):
-            image_uri = qp.images[0].uri
-            a.callmethod("remove_image", image_uri)
+            image_entry = qp.images[0]
+            a.callmethod("remove_image", image_entry)
 
         # test that we can reassign uri's even in readonly mode
         cur_uri = qp.images[0].uri


### PR DESCRIPTION
Draft of pull request related to #78.

Some time ago I implemented the possibility to remove an image from a QuPath project, although now I noticed that it is no longer working properly. In any case, maybe you can provide some feedback so I can figure out what I am doing wrong.

Points for review: 
- Calling `project.java_object.removeImage(image_entry_to_be_removed.java_object, True)` used to do the job, but now when I call that method the image is not deleted correctly. Instead, if I open the project in QuPath after "deleting" an image, I see that its thumbnail is gone (see attached screenshot), and when I click on it QuPath asks me to set the image type (as if the image was never opened before).

![Screen Shot 2022-11-08 at 14 38 31](https://user-images.githubusercontent.com/16247286/200580416-6cf875ad-53e3-4f2b-8281-e60bcb489bd5.jpg)


- Currently, the new `project.remove_image` method takes an image path as input and checks if it is indeed part of the project. Not sure if it makes more sense to pass the `entry_id` of the image to be deleted instead. If we pass the path, then we should also handle possible duplicates in the project (currently only the first instance with a given path is removed)


