### PR TITLE
Fix windows network share URIs in paquo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: end-of-file-fixer
   - id: check-added-large-files
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.37.2
+  rev: v3.2.2
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
@@ -21,13 +21,13 @@ repos:
 #   - id: black
 #     language_version: python3
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.971'
+  rev: 'v0.990'
   hooks:
   - id: mypy
     exclude: ^examples|^extras|^docs|tests.*
     additional_dependencies: [packaging, ome-types]
 - repo: https://github.com/PyCQA/flake8
-  rev: '4.0.1'
+  rev: '5.0.4'
   hooks:
   - id: flake8
     additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,4 @@ repos:
   rev: '1.7.4'
   hooks:
   - id: bandit
-    args: ["--ini", ".bandit"]
+    args: ["-lll", "--ini", ".bandit"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ where N is the issue number.
 ## Merge approval
 
 Repository maintainers will review the pull request and make sure it provides
-the appropriate level of code quality & correctness. 
+the appropriate level of code quality & correctness.
 
 
 ## How are decisions made?

--- a/paquo/images.py
+++ b/paquo/images.py
@@ -184,6 +184,9 @@ class SimpleURIImageProvider:
         """accepts a path and returns a URIString"""
         if not isinstance(image_id, (Path, str, SimpleURIImageProvider.FilenamePathId)):
             raise TypeError("image_id not of correct format")  # pragma: no cover
+        if isinstance(image_id, str) and "://" in image_id:
+            # image_id is uri
+            return SimpleURIImageProvider.URIString(image_id)
         img_path = pathlib.Path(image_id).absolute().resolve()
         if not img_path.is_file():
             return None

--- a/paquo/jpype_backend.py
+++ b/paquo/jpype_backend.py
@@ -33,12 +33,12 @@ JClass = jpype.JClass
 
 
 def find_qupath(*,
-                qupath_dir: PathOrStr = None,
-                qupath_search_dirs: Union[PathOrStr, List[PathOrStr]] = None,
-                qupath_search_dir_regex: str = None,
-                qupath_search_conda: bool = None,
-                qupath_prefer_conda: bool = None,
-                java_opts: Union[List[str], str] = None,
+                qupath_dir: Optional[PathOrStr] = None,
+                qupath_search_dirs: Optional[Union[PathOrStr, List[PathOrStr]]] = None,
+                qupath_search_dir_regex: Optional[str] = None,
+                qupath_search_conda: Optional[bool] = None,
+                qupath_prefer_conda: Optional[bool] = None,
+                java_opts: Optional[Union[List[str], str]] = None,
                 **_kwargs) -> QuPathJVMInfo:
     """find current qupath installation and jvm paths/options
 

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -301,9 +301,8 @@ class QuPathProject:
         if img_uri is None:
             raise FileNotFoundError(f"image_provider can't provide URI for requested image_id: '{image_id}'")
         img_id = self._image_provider.id(img_uri)
-        if not img_id == image_id:  # pragma: no cover
+        if img_id != image_id:  # pragma: no cover
             _log.warning(f"image_provider roundtrip error: '{image_id}' -> uri -> '{img_id}'")
-            raise RuntimeError("the image provider failed to roundtrip the image id correctly")
 
         if not allow_duplicates:
             for entry in self.images:
@@ -321,7 +320,7 @@ class QuPathProject:
             # it's possible that an image_provider returns an URI but that URI
             # is not actually reachable. In that case catch the java IOException
             # and raise a FileNotFoundError here
-            raise FileNotFoundError(image_id)
+            raise FileNotFoundError(img_uri)
         except ExceptionInInitializerError:
             raise OSError("no preferred support found")
         if not support:

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -311,11 +311,13 @@ class QuPathProject:
                 if img_id == uri:
                     raise FileExistsError(img_id)
 
+        img_pth = str(ImageProvider.path_from_uri(img_uri))
+
         # first get a server builder
         try:
             support = ImageServerProvider.getPreferredUriImageSupport(
                 BufferedImage,
-                String(str(img_uri))
+                String(img_pth),
             )
         except IOException:  # pragma: no cover
             # it's possible that an image_provider returns an URI but that URI

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -311,13 +311,11 @@ class QuPathProject:
                 if img_id == uri:
                     raise FileExistsError(img_id)
 
-        img_pth = str(ImageProvider.path_from_uri(img_uri))
-
         # first get a server builder
         try:
             support = ImageServerProvider.getPreferredUriImageSupport(
                 BufferedImage,
-                String(img_pth),
+                String(img_uri),
             )
         except IOException:  # pragma: no cover
             # it's possible that an image_provider returns an URI but that URI

--- a/paquo/tests/conftest.py
+++ b/paquo/tests/conftest.py
@@ -40,6 +40,14 @@ def svs_small():
         yield img_fn.absolute()
 
 
+@pytest.fixture(scope="function")
+def renamed_svs_small(request, tmp_path, svs_small):
+    name = request.param
+    new_path = tmp_path.joinpath(name)
+    new_path.write_bytes(svs_small.read_bytes())
+    yield new_path
+
+
 @pytest.fixture(scope='session')
 def qupath_version():
     from paquo.java import qupath_version

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import posixpath
 import shutil
 import tempfile
 from contextlib import nullcontext
@@ -183,12 +184,9 @@ def test_project_add_image(new_project, svs_small):
 def test_project_add_image_windows(new_project, svs_small):
     drive, *parts = svs_small.parts
 
-    # use the UNC path for the image
-    assert len(drive) == 3 and drive.endswith(":\\")
-    network_path = Path(f"//localhost/{drive[0].lower()}$", *parts)
-    assert network_path.exists()
+    uri = posixpath.join(f"file:////localhost/{drive[0].lower()}$", *parts)
 
-    _ = new_project.add_image(network_path)
+    _ = new_project.add_image(uri)
     assert len(new_project.images) == 1
 
 

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -182,8 +182,11 @@ def test_project_add_image(new_project, svs_small):
 @pytest.mark.skipif(platform.system() != "Windows", reason="windows only")
 def test_project_add_image_windows(new_project, svs_small):
     drive, *parts = svs_small.parts
+
+    # use the UNC path for the image
     assert len(drive) == 3 and drive.endswith(":\\")
-    network_path = Path(f"\\\\localhost\\{drive[0].lower()}$\\", *parts)
+    network_path = Path(f"//localhost/{drive[0].lower()}$", *parts)
+    assert network_path.exists()
 
     _ = new_project.add_image(network_path)
     assert len(new_project.images) == 1

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -179,6 +179,16 @@ def test_project_add_image(new_project, svs_small):
     assert object() not in new_project.images
 
 
+@pytest.mark.skipif(platform.system() != "Windows", reason="windows only")
+def test_project_add_image_windows(new_project, svs_small):
+    drive, *parts = svs_small.parts
+    assert len(drive) == 3 and drive.endswith(":\\")
+    network_path = Path(f"//localhost/{drive[0].lower()}$/", *parts)
+
+    _ = new_project.add_image(network_path)
+    assert len(new_project.images) == 1
+
+
 def test_project_add_image_writes_project(tmp_path, svs_small):
     qp = QuPathProject(tmp_path, mode='x')
     qp.add_image(svs_small)

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -183,7 +183,7 @@ def test_project_add_image(new_project, svs_small):
 def test_project_add_image_windows(new_project, svs_small):
     drive, *parts = svs_small.parts
     assert len(drive) == 3 and drive.endswith(":\\")
-    network_path = Path(f"//localhost/{drive[0].lower()}$/", *parts)
+    network_path = Path(f"\\\\localhost\\{drive[0].lower()}$\\", *parts)
 
     _ = new_project.add_image(network_path)
     assert len(new_project.images) == 1

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -190,6 +190,23 @@ def test_project_add_image_windows(new_project, svs_small):
     assert len(new_project.images) == 1
 
 
+@pytest.mark.skipif(platform.system() != "Windows", reason="windows only")
+@pytest.mark.parametrize(
+    "renamed_svs_small", [
+        pytest.param("abc.svs", id="simple_name"),
+        pytest.param("image%image.svs", id="name_with_percentage"),
+    ],
+    indirect=True,
+)
+def test_project_add_image_windows_unencoded_uri(new_project, renamed_svs_small):
+    drive, *parts = renamed_svs_small.parts
+
+    uri = posixpath.join(f"file:////localhost/{drive[0]}$", *parts)
+
+    _ = new_project.add_image(uri)
+    assert len(new_project.images) == 1
+
+
 def test_project_add_image_writes_project(tmp_path, svs_small):
     qp = QuPathProject(tmp_path, mode='x')
     qp.add_image(svs_small)
@@ -269,7 +286,7 @@ def test_project_delete_image_file_when_opened(new_project, svs_small):
 
     if qupath_uses == "BIOFORMATS":  # pragma: no cover
         if platform.system() == "Windows":
-            # NOTE: on windows because you can't delete files that have open
+            # NOTE: on Windows because you can't delete files that have open
             #   file handles. In this test we're deleting the file opened by
             #   the ImageServer on the java side. (this is happening
             #   implicitly when calling is_readable() because the java


### PR DESCRIPTION
Provides better URI handling by trying to normalise all `file://` URIs to a supported 4-slash version.

Closes #65 

See also:
- https://github.com/qupath/qupath/pull/1134
- https://github.com/qupath/qupath/pull/1049
- https://en.wikipedia.org/wiki/File_URI_scheme#Windows
- https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes

With PR 1134 merged in QuPath all of this logic might be removed for QuPath-0.4.x support.