### PR TITLE
ci: test against python 3.11

### DIFF
--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -19,7 +19,7 @@ jobs:
         include:
           # we'll test the python support on ubuntu
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest
@@ -72,9 +72,11 @@ jobs:
         with:
           python-version: 3.8
       - name: Install dependencies
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
+          pip install ome_types || true
       - name: Run mypy
         run: |
           mypy paquo

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -1,6 +1,10 @@
 name: paquo ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
 
 env:
   QUPATH_VERSION: 0.3.2

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -19,7 +19,7 @@ jobs:
         include:
           # we'll test the python support on ubuntu
           - os: ubuntu-latest
-            python-version: 3.11
+            python-version: 3.10
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -11,13 +11,15 @@ jobs:
     name: pytest ${{ matrix.os }}::py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 6
+      max-parallel: 7
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         include:
           # we'll test the python support on ubuntu
+          - os: ubuntu-latest
+            python-version: 3.11
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ dev =
     pytest>=6
     pytest-cov
     mypy
-    ome-types
+    ome-types; platform_system != 'Windows' or python_version < '3.11'
     importlib_resources
     typing_extensions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,8 +58,6 @@ dev =
     pytest>=6
     pytest-cov
     mypy
-    ome-types; platform_system != 'Windows' or python_version < '3.11'
-    importlib_resources
     typing_extensions
 
 docs =


### PR DESCRIPTION
run tests against 3.11 since Jpype supports it now.