### PR TITLE
Drop `python<3.10`, update ci and test against newest QuPath

### DIFF
--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -36,9 +36,6 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.9'
             qupath-version: '0.7.0'
-          - os: ubuntu-latest
-            python-version: '3.8'
-            qupath-version: '0.7.0'
           # we'll test older qupath support on ubuntu too
           - os: ubuntu-latest
             python-version: '3.14'

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -13,47 +13,54 @@ jobs:
     name: pytest ${{ matrix.os }}::qp${{ matrix.qupath-version }}::py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 8
+      max-parallel: 7
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13"]
-        qupath-version: ["0.6.0"]
+        python-version: ["3.14"]
+        qupath-version: ["0.7.0"]
         include:
           # we'll test the python support on ubuntu
           - os: ubuntu-latest
+            python-version: '3.13'
+            qupath-version: '0.7.0'
+          - os: ubuntu-latest
             python-version: '3.12'
-            qupath-version: '0.6.0'
+            qupath-version: '0.7.0'
           - os: ubuntu-latest
             python-version: '3.11'
-            qupath-version: '0.6.0'
+            qupath-version: '0.7.0'
           - os: ubuntu-latest
             python-version: '3.10'
-            qupath-version: '0.6.0'
+            qupath-version: '0.7.0'
           - os: ubuntu-latest
             python-version: '3.9'
-            qupath-version: '0.6.0'
+            qupath-version: '0.7.0'
           - os: ubuntu-latest
             python-version: '3.8'
+            qupath-version: '0.7.0'
+          # we'll test older qupath support on ubuntu too
+          - os: ubuntu-latest
+            python-version: '3.14'
             qupath-version: '0.6.0'
           - os: ubuntu-latest
-            python-version: '3.13'
+            python-version: '3.14'
             qupath-version: '0.5.1'
           - os: ubuntu-latest
-            python-version: '3.13'
+            python-version: '3.14'
             qupath-version: '0.4.4'
           - os: ubuntu-latest
-            python-version: '3.13'
+            python-version: '3.14'
             qupath-version: '0.3.2'
           - os: ubuntu-latest
-            python-version: '3.13'
+            python-version: '3.14'
             qupath-version: '0.2.3'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install paquo
@@ -61,7 +68,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
     - name: Restore qupath cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
         CACHE_NUMBER: 0
       with:
@@ -77,7 +84,7 @@ jobs:
       run: |
         pytest --cov=./paquo --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         name: paquo
 
@@ -86,13 +93,13 @@ jobs:
     name: mypy type analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.14
       - name: Install dependencies
         shell: bash
         run: |
@@ -110,13 +117,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.14
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -144,7 +151,7 @@ jobs:
       # push all versions on master to test.pypi.org
       - name: Publish package to TestPyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.test_pypi_password }}
@@ -157,13 +164,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.14
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -183,7 +190,7 @@ jobs:
           .
       # push all tagged versions to pypi.org
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -33,9 +33,6 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.10'
             qupath-version: '0.7.0'
-          - os: ubuntu-latest
-            python-version: '3.9'
-            qupath-version: '0.7.0'
           # we'll test older qupath support on ubuntu too
           - os: ubuntu-latest
             python-version: '3.14'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   rev: v3.15.2
   hooks:
   - id: pyupgrade
-    args: [--py39-plus]
+    args: [--py310-plus]
 - repo: https://github.com/pycqa/isort
   rev: 5.13.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   rev: v3.15.2
   hooks:
   - id: pyupgrade
-    args: [--py38-plus]
+    args: [--py39-plus]
 - repo: https://github.com/pycqa/isort
   rev: 5.13.2
   hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/examples/example_05_draw_tiles_on_image.py
+++ b/examples/example_05_draw_tiles_on_image.py
@@ -3,7 +3,8 @@ import itertools
 import math
 import random
 from pathlib import Path
-from typing import Tuple, Iterator
+from typing import Tuple
+from collections.abc import Iterator
 
 from shapely.geometry import Polygon
 
@@ -21,7 +22,7 @@ def measurement(x, y, w, h, a=8) -> float:
     return min(max(0., v), 1.)
 
 
-def iterate_grid(width, height, grid_size) -> Iterator[Tuple[int, int]]:
+def iterate_grid(width, height, grid_size) -> Iterator[tuple[int, int]]:
     """return corner x,y coordinates for a grid"""
     yield from itertools.product(
         range(0, width, grid_size),

--- a/paquo/__main__.py
+++ b/paquo/__main__.py
@@ -6,11 +6,11 @@ import os
 import platform
 import sys
 import tempfile
+from collections.abc import Callable
 from contextlib import redirect_stdout
 from itertools import repeat
 from logging.config import dictConfig
 from pathlib import Path
-from typing import Callable
 
 from paquo._cli import DirectoryType
 from paquo._cli import argument

--- a/paquo/_cli.py
+++ b/paquo/_cli.py
@@ -54,13 +54,10 @@ def config_print_settings():
 
 def config_print_defaults():
     """print the default paquo configuration"""
-    if sys.version_info >= (3, 9):
-        from importlib.resources import files
+    from importlib.resources import files
 
-        def read_text(package, resource, encoding):
-            return files(package).joinpath(resource).read_text(encoding=encoding)
-    else:
-        from importlib.resources import read_text
+    def read_text(package, resource, encoding):
+        return files(package).joinpath(resource).read_text(encoding=encoding)
 
     from paquo._config import settings
 

--- a/paquo/_config.py
+++ b/paquo/_config.py
@@ -1,5 +1,6 @@
-import sys
 import tempfile
+from importlib.resources import as_file
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -12,15 +13,9 @@ from dynaconf.base import Settings
 from dynaconf.utils import files as _files
 from dynaconf.utils.boxing import DynaBox
 
-if sys.version_info >= (3, 9):
-    from importlib.resources import as_file
-    from importlib.resources import files
 
-    def importlib_resources_path(package, resource):
-        return as_file(files(package).joinpath(resource))
-
-else:
-    from importlib.resources import path as importlib_resources_path
+def importlib_resources_path(package, resource):
+    return as_file(files(package).joinpath(resource))
 
 
 PAQUO_CONFIG_FILENAME = '.paquo.toml'
@@ -40,7 +35,7 @@ _PAQUO_FIX_CONFIG_KEYS = {
 }
 
 
-def to_kwargs(s: "Settings | DynaBox") -> Dict[str, Any]:
+def to_kwargs(s: "Settings | DynaBox") -> dict[str, Any]:
     """convert dynaconf settings to lowercase"""
     dct = s.to_dict()
     out = {}
@@ -97,10 +92,10 @@ def _get_settings() -> Dynaconf:
 settings = _get_settings()
 
 
-def get_searchtree() -> List[str]:
+def get_searchtree() -> list[str]:
     """return the current search tree for the settings"""
     if not settings.configured:
         settings.configure()  # pragma: no cover
     # note: SEARCHTREE is updated after configure
-    searchtree: List[str] = getattr(_files, 'SEARCHTREE', [])
+    searchtree: list[str] = getattr(_files, 'SEARCHTREE', [])
     return searchtree

--- a/paquo/_logging.py
+++ b/paquo/_logging.py
@@ -1,12 +1,12 @@
 import atexit
 import logging
 import re
+from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from contextlib import ContextDecorator
 from contextlib import ExitStack
 from contextlib import contextmanager
 from contextlib import suppress
-from typing import Iterable
 from typing import List
 from typing import Tuple
 
@@ -122,9 +122,9 @@ class _JavaLoggingBase(AbstractContextManager):
             else:
                 self._logger.info("[%s] [%s] - %s", origin, level, entry)
 
-    def iter_logs(self, output: str) -> Iterable[Tuple[Tuple[str, str], str]]:
+    def iter_logs(self, output: str) -> Iterable[tuple[tuple[str, str], str]]:
         """iterate the individual log messages"""
-        entry: List[str] = []
+        entry: list[str] = []
         info = ('NONE', 'NONE')
         for line in output.splitlines(keepends=True):
             if not line.strip():

--- a/paquo/classes.py
+++ b/paquo/classes.py
@@ -24,7 +24,7 @@ class QuPathPathClass:
 
     def __init__(self,
                  name: str,
-                 color: Optional[ColorType] = None,
+                 color: ColorType | None = None,
                  parent: Optional['QuPathPathClass'] = None,
                  **_kwargs) -> None:
         """create a QuPathPathClass
@@ -130,7 +130,7 @@ class QuPathPathClass:
         return self.java_object.isAncestorOf(child_class.java_object)
 
     @property
-    def color(self) -> Optional[QuPathColor]:
+    def color(self) -> QuPathColor | None:
         """return the path color"""
         rgb = self.java_object.getColor()
         if rgb is None:
@@ -138,7 +138,7 @@ class QuPathPathClass:
         return QuPathColor.from_java_rgb(rgb)
 
     @color.setter
-    def color(self, rgb: Optional[ColorType]) -> None:
+    def color(self, rgb: ColorType | None) -> None:
         """set the path color"""
         if rgb is not None:
             rgb = QuPathColor.from_any(rgb).to_java_rgb()  # maybe use argb?

--- a/paquo/colors.py
+++ b/paquo/colors.py
@@ -6,8 +6,8 @@ from typing import Union
 from paquo.java import ColorTools
 from paquo.java import Integer
 
-ColorTypeRGB = Tuple[int, int, int]
-ColorTypeRGBA = Tuple[int, int, int, int]
+ColorTypeRGB = tuple[int, int, int]
+ColorTypeRGBA = tuple[int, int, int, int]
 ColorType = Union[ColorTypeRGB, ColorTypeRGBA, 'QuPathColor', str]
 
 
@@ -40,7 +40,7 @@ class QuPathColor(NamedTuple):
         """convert to 4 * uint8 rgba tuple"""
         return self.red, self.green, self.blue, self.alpha
 
-    def to_mpl_rgba(self) -> Tuple[float, float, float, float]:
+    def to_mpl_rgba(self) -> tuple[float, float, float, float]:
         """convert to 4 * float rgba tuple (mpl compatible)"""
         r, g, b, a = self.to_rgba()
         return r / 255.0, g / 255.0, b / 255.0, a / 255.0

--- a/paquo/hierarchy.py
+++ b/paquo/hierarchy.py
@@ -4,15 +4,15 @@ import math
 import reprlib
 import struct
 import warnings
+from collections import Counter as CounterType
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import MutableSet
+from collections.abc import Sequence
 from contextlib import contextmanager
 from contextlib import suppress
 from typing import Any
-from typing import Counter as CounterType
-from typing import Iterable
-from typing import Iterator
-from typing import MutableSet
 from typing import Optional
-from typing import Sequence
 from typing import Type
 from typing import Union
 from typing import overload
@@ -57,9 +57,9 @@ class PathObjectProxy(Sequence[PathROIObjectType], MutableSet[PathROIObjectType]
     def __init__(
         self,
         hierarchy: 'QuPathPathObjectHierarchy',
-        paquo_cls: Type[PathROIObjectType],
-        mask: Optional[Union[slice, Sequence[int]]] = None,
-        readonly: Optional[bool] = None,
+        paquo_cls: type[PathROIObjectType],
+        mask: slice | Sequence[int] | None = None,
+        readonly: bool | None = None,
     ) -> None:
         """internal: not meant to be instantiated by the user"""
         self._hierarchy = hierarchy
@@ -70,7 +70,7 @@ class PathObjectProxy(Sequence[PathROIObjectType], MutableSet[PathROIObjectType]
             or (all(isinstance(x, int) for x in mask) and len(mask) > 0)
         ):
             raise TypeError(f"mask can be slice, or Sequence[int] or None. Got: {type(mask)!r}")
-        self._mask: Optional[Union[slice, Sequence[int]]] = mask
+        self._mask: slice | Sequence[int] | None = mask
         self._init_readonly = readonly
 
     @property
@@ -260,7 +260,7 @@ class QuPathPathObjectHierarchy:
 
     def __init__(
         self,
-        hierarchy: Optional[PathObjectHierarchy] = None,
+        hierarchy: PathObjectHierarchy | None = None,
         *,
         readonly: bool = False,
         image_name: str = "N/A",
@@ -335,8 +335,8 @@ class QuPathPathObjectHierarchy:
 
     def add_annotation(self,
                        roi: BaseGeometry,
-                       path_class: Optional[QuPathPathClass] = None,
-                       measurements: Optional[dict] = None,
+                       path_class: QuPathPathClass | None = None,
+                       measurements: dict | None = None,
                        *,
                        path_class_probability: float = math.nan) -> QuPathPathAnnotationObject:
         """convenience method for adding annotations"""
@@ -356,8 +356,8 @@ class QuPathPathObjectHierarchy:
 
     def add_detection(self,
                       roi: BaseGeometry,
-                      path_class: Optional[QuPathPathClass] = None,
-                      measurements: Optional[dict] = None,
+                      path_class: QuPathPathClass | None = None,
+                      measurements: dict | None = None,
                       *,
                       path_class_probability: float = math.nan) -> QuPathPathDetectionObject:
         if self._readonly:
@@ -382,8 +382,8 @@ class QuPathPathObjectHierarchy:
 
     def add_tile(self,
                  roi: BaseGeometry,
-                 path_class: Optional[QuPathPathClass] = None,
-                 measurements: Optional[dict] = None,
+                 path_class: QuPathPathClass | None = None,
+                 measurements: dict | None = None,
                  *,
                  path_class_probability: float = math.nan) -> QuPathPathTileObject:
         """convenience method for adding tile detections
@@ -408,8 +408,8 @@ class QuPathPathObjectHierarchy:
 
     def add_cell(self,
                  roi: BaseGeometry,
-                 path_class: Optional[QuPathPathClass] = None,
-                 measurements: Optional[dict] = None,
+                 path_class: QuPathPathClass | None = None,
+                 measurements: dict | None = None,
                  *,
                  path_class_probability: float = math.nan,
                  nucleus_roi: BaseGeometry) -> QuPathPathCellObject:
@@ -566,7 +566,7 @@ class QuPathPathObjectHierarchy:
 
         for ao in self.annotations:
 
-            class_name: Optional[str]
+            class_name: str | None
             if ao.path_class:
                 class_name = ao.path_class.name
             else:

--- a/paquo/images.py
+++ b/paquo/images.py
@@ -3,6 +3,7 @@ import pathlib
 import re
 import warnings
 import weakref
+from collections.abc import Iterator
 from collections.abc import MutableMapping
 from copy import deepcopy
 from enum import Enum
@@ -13,7 +14,6 @@ from pathlib import PureWindowsPath
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
-from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Union
@@ -152,7 +152,7 @@ class ImageProvider:
             raise TypeError("uri not of correct format")  # pragma: no cover
         return ImageProvider.FilenamePathId(ImageProvider.path_from_uri(uri))
 
-    def rebase(self, *uris: str, **kwargs) -> List[Optional[str]]:
+    def rebase(self, *uris: str, **kwargs) -> list[str | None]:
         uri2uri = kwargs.pop('uri2uri', {})
         return [uri2uri.get(uri, None) for uri in uris]
 
@@ -544,7 +544,7 @@ class QuPathProjectImageEntry:
         return int(self._image_server.nTimepoints())
 
     @cached_property
-    def downsample_levels(self) -> List[Dict[str, float]]:
+    def downsample_levels(self) -> list[dict[str, float]]:
         """downsample levels provided by the image
 
         Notes

--- a/paquo/jpype_backend.py
+++ b/paquo/jpype_backend.py
@@ -4,16 +4,16 @@ import re
 import shlex
 import sys
 import textwrap
+from collections.abc import Callable
+from collections.abc import Iterable
 from contextlib import contextmanager
 from contextlib import nullcontext
 from itertools import chain
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
-from typing import Callable
 from typing import ContextManager
 from typing import Dict
-from typing import Iterable
 from typing import List
 from typing import NamedTuple
 from typing import Optional
@@ -36,17 +36,17 @@ class QuPathJVMInfo(NamedTuple):
     app_dir: Path
     runtime_dir: Path
     jvm_path: Path
-    jvm_options: List[str]
+    jvm_options: list[str]
 
 
 def find_qupath(*,
-                qupath_dir: Optional[PathOrStr] = None,
-                qupath_search_dirs: Optional[Union[PathOrStr, List[PathOrStr]]] = None,
-                qupath_search_dir_regex: Optional[str] = None,
-                qupath_search_conda: Optional[bool] = None,
-                qupath_prefer_conda: Optional[bool] = None,
-                java_opts: Optional[Union[List[str], str]] = None,
-                jvm_path_override: Optional[PathOrStr] = None,
+                qupath_dir: PathOrStr | None = None,
+                qupath_search_dirs: PathOrStr | list[PathOrStr] | None = None,
+                qupath_search_dir_regex: str | None = None,
+                qupath_search_conda: bool | None = None,
+                qupath_prefer_conda: bool | None = None,
+                java_opts: list[str] | str | None = None,
+                jvm_path_override: PathOrStr | None = None,
                 **_kwargs) -> QuPathJVMInfo:
     """find current qupath installation and jvm paths/options
 
@@ -111,7 +111,7 @@ def find_qupath(*,
         raise ValueError("no valid qupath installation found")
 
 
-def _scan_qupath_dirs(qupath_search_dirs: List[PathOrStr], qupath_search_dir_regex: str) -> Iterable[Path]:
+def _scan_qupath_dirs(qupath_search_dirs: list[PathOrStr], qupath_search_dir_regex: str) -> Iterable[Path]:
     """return potential paths for QuPath"""
     qp_match = re.compile(qupath_search_dir_regex).match
     for location in map(Path, qupath_search_dirs):
@@ -123,7 +123,7 @@ def _scan_qupath_dirs(qupath_search_dirs: List[PathOrStr], qupath_search_dir_reg
                     yield Path(dir_entry.path)
 
 
-def _conda_qupath_dir() -> Optional[Path]:
+def _conda_qupath_dir() -> Path | None:
     """return the conda qupath if running in a conda env"""
     prefix = os.environ.get('CONDA_PREFIX')
     if prefix:
@@ -139,7 +139,7 @@ def _conda_qupath_dir() -> Optional[Path]:
     return None
 
 
-def qupath_jvm_info_from_qupath_dir(qupath_dir: Path, jvm_options: List[str]) -> QuPathJVMInfo:
+def qupath_jvm_info_from_qupath_dir(qupath_dir: Path, jvm_options: list[str]) -> QuPathJVMInfo:
     """convert qupath_dir to paths according to platform"""
     system = platform.system()
     if system == "Linux":
@@ -172,13 +172,13 @@ def qupath_jvm_info_from_qupath_dir(qupath_dir: Path, jvm_options: List[str]) ->
 
 
 # stores qupath version to handle consecutive calls to start_jvm
-_QUPATH_VERSION: Optional[QuPathVersion] = None
+_QUPATH_VERSION: QuPathVersion | None = None
 
 
 def start_jvm(
-    finder: Optional[Callable[..., QuPathJVMInfo]] = None,
-    finder_kwargs: Optional[Dict[str, Any]] = None,
-) -> Optional[QuPathVersion]:
+    finder: Callable[..., QuPathJVMInfo] | None = None,
+    finder_kwargs: dict[str, Any] | None = None,
+) -> QuPathVersion | None:
     """start the jvm via jpype
 
     This is automatically called at import of `paquo.java`.

--- a/paquo/pathobjects.py
+++ b/paquo/pathobjects.py
@@ -1,9 +1,9 @@
 import json
 import math
+from collections.abc import Callable
+from collections.abc import Iterator
 from collections.abc import MutableMapping
 from functools import partial
-from typing import Callable
-from typing import Iterator
 from typing import Optional
 from typing import Type
 from typing import TypeVar
@@ -84,7 +84,7 @@ class _MeasurementList(MutableMapping):
         self,
         measurement_list,
         *,
-        update_callback: Optional[Callable[[], None]] = None
+        update_callback: Callable[[], None] | None = None
     ):
         self._measurement_list = measurement_list
         self._update_callback = update_callback
@@ -106,7 +106,7 @@ class _MeasurementList(MutableMapping):
         if self._update_callback:
             self._update_callback()
 
-    def __getitem__(self, k: Union[str, int]) -> float:
+    def __getitem__(self, k: str | int) -> float:
         if not isinstance(k, (int, str)):
             raise KeyError(f"unsupported key of type {type(k)}")
         if compatibility.supports_newer_measurements_interface:
@@ -156,24 +156,24 @@ class _PathROIObject:
     """internal base class for PathObjects"""
 
     # must be provided in subclass
-    java_class: Type[PathROIObject]
+    java_class: type[PathROIObject]
     java_class_factory: Callable[..., PathROIObject]
 
     def __init__(
         self,
         java_object: PathROIObject,
         *,
-        update_callback: Optional[Callable[[PathROIObjectType], None]] = None
+        update_callback: Callable[[PathROIObjectType], None] | None = None
     ) -> None:
         """instantiate using classmethods: `from_shapely`, `from_geojson`"""
         self.java_object = java_object
         self._update_callback = update_callback
 
     @classmethod
-    def from_shapely(cls: Type[PathROIObjectType],
+    def from_shapely(cls: type[PathROIObjectType],
                      roi: BaseGeometry,
-                     path_class: Optional[QuPathPathClass] = None,
-                     measurements: Optional[dict] = None,
+                     path_class: QuPathPathClass | None = None,
+                     measurements: dict | None = None,
                      *,
                      path_class_probability: float = math.nan) -> "PathROIObjectType":
         """create a Path Object from a shapely shape
@@ -205,7 +205,7 @@ class _PathROIObject:
         return obj
 
     @classmethod
-    def from_geojson(cls: Type[PathROIObjectType], geojson) -> PathROIObjectType:
+    def from_geojson(cls: type[PathROIObjectType], geojson) -> PathROIObjectType:
         """create a new Path Object from geojson"""
         gson = GsonTools.getInstance()
         java_obj = gson.fromJson(String(json.dumps(geojson)), cls.java_class)
@@ -218,7 +218,7 @@ class _PathROIObject:
         return dict(json.loads(str(geojson)))
 
     @property
-    def path_class(self) -> Optional[QuPathPathClass]:
+    def path_class(self) -> QuPathPathClass | None:
         """the annotation path class"""
         pc = self.java_object.getPathClass()
         if not pc:
@@ -230,7 +230,7 @@ class _PathROIObject:
         """the annotation path class probability"""
         return float(self.java_object.getClassProbability())
 
-    def update_path_class(self: PathROIObjectType, pc: Optional[QuPathPathClass], probability: float = math.nan) -> None:
+    def update_path_class(self: PathROIObjectType, pc: QuPathPathClass | None, probability: float = math.nan) -> None:
         """updating the class or probability has to be done via this method"""
         if not (pc is None or isinstance(pc, QuPathPathClass)):
             raise TypeError("requires QuPathPathClass")
@@ -262,7 +262,7 @@ class _PathROIObject:
         return int(self.java_object.getLevel())
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """an optional name for the annotation"""
         name = self.java_object.getName()
         if name is None:
@@ -270,7 +270,7 @@ class _PathROIObject:
         return str(name)
 
     @name.setter
-    def name(self: PathROIObjectType, name: Union[str, None]) -> None:
+    def name(self: PathROIObjectType, name: str | None) -> None:
         if name is not None:
             name = String(name)
         self.java_object.setName(name)
@@ -278,7 +278,7 @@ class _PathROIObject:
             self._update_callback(self)  # type: ignore[arg-type]
 
     @property
-    def parent(self: PathROIObjectType) -> Optional[PathROIObjectType]:
+    def parent(self: PathROIObjectType) -> PathROIObjectType | None:
         """the annotation object's parent annotation object"""
         parent = self.java_object.getParent()
         if not parent:
@@ -370,7 +370,7 @@ class QuPathPathAnnotationObject(_PathROIObject):
     java_class_factory = PathObjects.createAnnotationObject
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         """an optional description for the annotation"""
         desc = self.java_object.getDescription()
         return str(desc) if desc is not None else None
@@ -408,11 +408,11 @@ class QuPathPathCellObject(QuPathPathDetectionObject):
     @classmethod
     def from_shapely(cls,
                      roi: BaseGeometry,
-                     path_class: Optional[QuPathPathClass] = None,
-                     measurements: Optional[dict] = None,
+                     path_class: QuPathPathClass | None = None,
+                     measurements: dict | None = None,
                      *,
                      path_class_probability: float = math.nan,
-                     nucleus_roi: Optional[BaseGeometry] = None) -> "QuPathPathCellObject":
+                     nucleus_roi: BaseGeometry | None = None) -> "QuPathPathCellObject":
         """create a Path Object from a shapely shape
 
         Parameters

--- a/paquo/projects.py
+++ b/paquo/projects.py
@@ -3,18 +3,18 @@ import math
 import pathlib
 import re
 import shutil
+from collections.abc import Callable
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import Sequence
 from contextlib import contextmanager
 from contextlib import nullcontext
 from typing import Any
-from typing import Callable
 from typing import ContextManager
 from typing import Dict
-from typing import Iterable
-from typing import Iterator
 from typing import List
 from typing import Literal
 from typing import Optional
-from typing import Sequence
 from typing import Tuple
 from typing import Union
 from typing import overload
@@ -169,7 +169,7 @@ class QuPathProject:
     java_object: DefaultProject
 
     def __init__(self,
-                 path: Union[str, pathlib.Path],
+                 path: str | pathlib.Path,
                  mode: ProjectIOMode = 'r',
                  *,
                  image_provider: ImageProvider = DEFAULT_IMAGE_PROVIDER):
@@ -272,33 +272,33 @@ class QuPathProject:
     def add_image(
         self,
         image_id: SimpleFileImageId,
-        image_type: Optional[QuPathImageType] = ...,
+        image_type: QuPathImageType | None = ...,
         *,
         allow_duplicates: bool = ...,
         return_list: Literal[True],
-    ) -> List[QuPathProjectImageEntry]:
+    ) -> list[QuPathProjectImageEntry]:
         ...
 
     @overload
     def add_image(
         self,
         image_id: SimpleFileImageId,
-        image_type: Optional[QuPathImageType] = ...,
+        image_type: QuPathImageType | None = ...,
         *,
         allow_duplicates: bool = ...,
         return_list: Literal[False] = ...,
-    ) -> Union[QuPathProjectImageEntry, List[QuPathProjectImageEntry]]:
+    ) -> QuPathProjectImageEntry | list[QuPathProjectImageEntry]:
         ...
 
     @redirect(stderr=True, stdout=True)
     def add_image(
         self,
         image_id: SimpleFileImageId,
-        image_type: Optional[QuPathImageType] = None,
+        image_type: QuPathImageType | None = None,
         *,
         allow_duplicates: bool = False,
         return_list: bool = False,
-    ) -> Union[QuPathProjectImageEntry, List[QuPathProjectImageEntry]]:
+    ) -> QuPathProjectImageEntry | list[QuPathProjectImageEntry]:
         """add an image to the project
 
         Parameters
@@ -390,7 +390,7 @@ class QuPathProject:
         else:
             return entries[0]
 
-    def is_readable(self) -> Dict[str, bool]:
+    def is_readable(self) -> dict[str, bool]:
         """verify if images are reachable"""
         readability_map = {}
         for image in self.images:
@@ -463,7 +463,7 @@ class QuPathProject:
     @redirect(stderr=True, stdout=True)
     def remove_image(
         self,
-        image_entry: Union[QuPathProjectImageEntry, int],
+        image_entry: QuPathProjectImageEntry | int,
     ) -> None:
         """
         Delete an image from the QuPath project.
@@ -501,7 +501,7 @@ class QuPathProject:
     #     return str(uri.toString())
 
     @property
-    def path_classes(self) -> Tuple[QuPathPathClass, ...]:
+    def path_classes(self) -> tuple[QuPathPathClass, ...]:
         """return path_classes stored in the project"""
         return tuple(map(QuPathPathClass.from_java, self.java_object.getPathClasses()))
 
@@ -578,7 +578,7 @@ class QuPathProject:
         return int(self.java_object.getModificationTimestamp())
 
     @property
-    def version(self) -> Optional[str]:
+    def version(self) -> str | None:
         """the project version. should be identical to the qupath version"""
         # for older projects this returns null.
         # for newer projects this will be set to DefaultProject.LATEST_VERSION

--- a/paquo/tests/conftest.py
+++ b/paquo/tests/conftest.py
@@ -1,7 +1,6 @@
 import hashlib
 import pathlib
 import shutil
-import sys
 import urllib.request
 
 import pytest
@@ -16,10 +15,7 @@ IMAGES_FALLBACK_URL = (
 
 
 def md5(fn):
-    if sys.version_info >= (3, 9):
-        m = hashlib.md5(usedforsecurity=False)
-    else:
-        m = hashlib.md5()  # nosec B324
+    m = hashlib.md5(usedforsecurity=False)
     with open(fn, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             m.update(chunk)

--- a/paquo/tests/conftest.py
+++ b/paquo/tests/conftest.py
@@ -8,6 +8,11 @@ import pytest
 
 # openslide aperio test images
 IMAGES_BASE_URL = "http://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/"
+# fallback mirror (libvips test suite)
+IMAGES_FALLBACK_URL = (
+    "https://raw.githubusercontent.com/libvips/libvips/"
+    "7a1eb7171dc6930fea1400634073d74295aa256b/test/test-suite/images/"
+)
 
 
 def md5(fn):
@@ -32,10 +37,19 @@ def svs_small():
     img_fn = data_dir / small_image
 
     if not img_fn.is_file():
-        # download svs from openslide test images
-        url = IMAGES_BASE_URL + small_image
-        with urllib.request.urlopen(url) as response, open(img_fn, 'wb') as out_file:  # nosec B310
-            shutil.copyfileobj(response, out_file)
+        # download svs from openslide test images, with fallback to libvips mirror
+        urls = [IMAGES_BASE_URL + small_image, IMAGES_FALLBACK_URL + small_image]
+        last_err = None
+        for url in urls:
+            try:
+                with urllib.request.urlopen(url) as response, open(img_fn, 'wb') as out_file:  # nosec B310
+                    shutil.copyfileobj(response, out_file)
+                break
+            except Exception as err:  # noqa: BLE001
+                last_err = err
+                continue
+        else:
+            pytest.fail(f"could not download {small_image}: {last_err!r}")
 
     if md5(img_fn) != small_image_md5:  # pragma: no cover
         shutil.rmtree(img_fn)

--- a/paquo/tests/test_hierarchy.py
+++ b/paquo/tests/test_hierarchy.py
@@ -33,7 +33,7 @@ def test_initial_state(empty_hierarchy: QuPathPathObjectHierarchy):
 _T = TypeVar('_T', bound=_PathROIObject)
 
 
-def _make_polygons(obj_cls: Type[_T], amount: int) -> List[_T]:
+def _make_polygons(obj_cls: type[_T], amount: int) -> list[_T]:
     """returns a list of amount Path Objects"""
     path_objects = []
     for x in range(0, 10 * amount, 10):

--- a/paquo/tests/test_images.py
+++ b/paquo/tests/test_images.py
@@ -237,7 +237,7 @@ def test_image_type(image_entry):
     assert image_entry.image_type == QuPathImageType.BRIGHTFIELD_H_E
 
 
-TEST_URIS: Dict[str, Dict] = {
+TEST_URIS: dict[str, dict] = {
     "no-uri": {  # weird non-uri found in one project
         "uri": "\\\\SHARE\\site\\2020-01-01\\image 123-X,X.svs",
         "parts": None,

--- a/paquo/tests/test_projects.py
+++ b/paquo/tests/test_projects.py
@@ -375,7 +375,12 @@ def test_project_image_uri_update(tmp_path, svs_small):
         assert all(qp.is_readable().values())
 
 
-def test_project_image_uri_update_try_relative(tmp_path, svs_small):
+def test_project_image_uri_update_try_relative(tmp_path, svs_small, qupath_version):
+    if platform.system() == "Windows" and qupath_version >= QuPathVersion("0.7.0"):
+        pytest.xfail(
+            "Windows QuPath==0.7.0 quirk with try_relative path update, "
+            "see https://github.com/Bayer-Group/paquo/issues/130"
+        )
 
     # prepare initial location
     location_0 = tmp_path / "location_0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,12 @@ classifiers =
     Programming Language :: Java
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Visualization
     Topic :: Scientific/Engineering :: Information Analysis
@@ -34,7 +35,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     dynaconf>=3,!=3.1.0
     JPype1>=1.0.1,!=1.5.1
@@ -72,7 +73,7 @@ console_scripts =
 
 
 [mypy]
-python_version = 3.8
+python_version = 3.9
 plugins = pydantic.mypy
 warn_return_any = True
 warn_unused_configs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Java
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -35,7 +34,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     dynaconf>=3,!=3.1.0
     JPype1>=1.0.1,!=1.5.1
@@ -73,7 +72,7 @@ console_scripts =
 
 
 [mypy]
-python_version = 3.9
+python_version = 3.10
 plugins = pydantic.mypy
 warn_return_any = True
 warn_unused_configs = True


### PR DESCRIPTION
This pull request updates the CI workflow and improves test robustness. The main changes include updating GitHub Actions versions, expanding the testing matrix for newer Python and QuPath versions, adding fallback logic for test image downloads, and updating a test for a known Windows/QuPath issue.

**CI/CD workflow updates:**

* Updated all GitHub Actions used in `.github/workflows/run_pytests.yaml` to their latest major versions (e.g., `actions/checkout@v6`, `actions/setup-python@v6`, `actions/cache@v5`, `codecov/codecov-action@v5`, `pypa/gh-action-pypi-publish@release/v1`) for improved reliability and security. 
* Updated the Python and QuPath versions in the test matrix to include Python 3.14 and QuPath 0.7.0, while still testing older QuPath versions for backward compatibility.

**Test robustness improvements:**

* Added a fallback mirror (`libvips` test suite) for downloading test images in `paquo/tests/conftest.py`, increasing reliability if the primary source is unavailable. [[1]](diffhunk://#diff-94206e6b42b136ba956f1529577b89898fb5ac3cfa235f11c07b995429765c8aR11-R15) [[2]](diffhunk://#diff-94206e6b42b136ba956f1529577b89898fb5ac3cfa235f11c07b995429765c8aL35-R52)

**Test compatibility:**

* Updated the `test_project_image_uri_update_try_relative` test to mark expected failures on Windows with QuPath 0.7.0 or newer, due to a known issue.
